### PR TITLE
Retrieve the current device locale and initialize it before runApp

### DIFF
--- a/packages/flutter_translate/lib/localization_delegate.dart
+++ b/packages/flutter_translate/lib/localization_delegate.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/widgets.dart';
 import 'configuration_validator.dart';
 import 'locale_service.dart';
@@ -85,7 +87,12 @@ class LocalizationDelegate extends LocalizationsDelegate<Localization>
 
     Future _initializePreferences() async
     {
-        if(preferences == null) return;
+        if(preferences == null)
+        {
+          var locale = Locale(Platform.localeName);
+          await changeLocale(locale);
+          return;
+        }
 
         var locale = await preferences.getPreferredLocale();
 


### PR DESCRIPTION
Fixes issue #13 and possibly #14 but I don't have an iOS device to test on. Takes into account if there are preferences on the device and if not loads the device locale. 