### PR TITLE
Use ELSE when 0 or 1 not found at plural translate

### DIFF
--- a/lib/localization.dart
+++ b/lib/localization.dart
@@ -95,6 +95,6 @@ class Localization
             }
         }
 
-        return map[key][valueKey];
+        return map[key][valueKey] ?? map[key][Constants.pluralElse];
     }
 }


### PR DESCRIPTION
Almost every time the value at 0 key is equal to the value at ELSE key. So, when 0 key is not set the return value will be the one at ELSE key.
Ex.:
```json
{
  "cat": {
    "1": "cat",
    "else": "cats"
  }
}
```