### PR TITLE
Added support for list of strings

### DIFF
--- a/lib/global.dart
+++ b/lib/global.dart
@@ -37,6 +37,11 @@ String translatePlural(String key, num value, {Map<String, dynamic> args})
 	return Localization.instance.plural(key, value, args: args);
 }
 
+List<String> translateList(String key, {Map<String, dynamic> args})
+{
+  return Localization.instance.list(key, args: args);
+}
+
 Future changeLocale(BuildContext context, String localeCode) async
 {
 	if (localeCode != null)

--- a/lib/localization.dart
+++ b/lib/localization.dart
@@ -44,6 +44,18 @@ class Localization
         return translation ?? '$key.$pluralKeyValue';
     }
 
+    List<String> list(String key, {Map<String, dynamic> args})
+    {
+      var translations = _getListTranslation(key, _translations);
+
+      if(translations != null && args != null)
+      {
+        translations = translations.map((t) => _assignArguments(t, args)).toList();
+      }
+
+      return List<String>.from(translations ?? [key]);
+    }
+
     String _getPluralKeyValue(num value)
     {
         switch(value)
@@ -96,5 +108,22 @@ class Localization
         }
 
         return map[key][valueKey] ?? map[key][Constants.pluralElse];
+    }
+
+    List<dynamic> _getListTranslation(String key, Map<String, dynamic> map)
+    {
+      List<String> keys = key.split('.');
+
+      if (keys.length > 1)
+        {
+            var firstKey = keys.first;
+
+            if(map.containsKey(firstKey) && map[firstKey] is! List<dynamic>)
+            {
+                return _getListTranslation(key.substring(key.indexOf('.') + 1), map[firstKey]);
+            }
+        }
+
+        return map[key];
     }
 }


### PR DESCRIPTION
## What

Added support to translate a list of strings.

## Why

For a project I'm working on I needed to get a list of strings to display in a random way (ex.: a pseudo bot that says different sentences for a specific action) using the nested json feature provided by [lokalise (link to specific doc page)](https://docs.lokalise.com/en/articles/1400773-json-nested-json).

## Example
json:
```JSON
{
   "level_1": {
      "attack": [
          "Your attack was effective",
          "You hit your enemy!"
      ]
   }
}
```
flutter:
```dart
import "dart:math";
import 'package:flutter/material.dart';
import 'package:flutter_translate/flutter_translate.dart';

class FightFeedback extends StatelessWidget {

  @override
  Widget build(BuildContext context) {
    final rnd = Random();
    final messages = translateList('level_1.attack');
    final message = messages[rnd.nextInt(messages.length)];

    return Text(message);
  }
}
```