### PR TITLE
fallback to fallback locale for missing strings in translation file

### DIFF
--- a/lib/localization_delegate.dart
+++ b/lib/localization_delegate.dart
@@ -33,7 +33,9 @@ class LocalizationDelegate extends LocalizationsDelegate<Localization>
 
         var localizedContent = await LocaleService.getLocaleContent(locale, supportedLocalesMap);
 
-        Localization.load(localizedContent);
+        var fallbackContent = locale != fallbackLocale ? await LocaleService.getLocaleContent(fallbackLocale, supportedLocalesMap) : null;
+
+        Localization.load(localizedContent, fallback: fallbackContent);
 
         _currentLocale = locale;
 


### PR DESCRIPTION
Currently, if a translation file is incomplete (i.e. a key is missing), then we will show the `key` instead of a translation. But for me it would be more intuitive to fallback to the `fallbackLocale` in these cases.

This allows to iteratively translate an App and if something is forgotten or not yet translated, we have a more meaningful placeholder.

Currently, I just load both translation maps (the chosen locale and the fallback locale) and then fallback during lookup. Another alternative is to merge the maps in the beginning and then just have one translation map.

Let me know, what you think. We could also make this a setting.