### PR TITLE
allow locales to be outside of the rootBundle

### DIFF
--- a/lib/locale_file_service.dart
+++ b/lib/locale_file_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:flutter/services.dart';
 import 'constants.dart';
 
@@ -22,7 +23,18 @@ class LocaleFileService
 
     static Future<String> getLocaleContent(String file) async
     {
-        return await rootBundle.loadString(file);
+        if (file == null) return null;
+
+        if (file.startsWith("/")) {
+          File f = File(file);
+          if (await f.exists()) {
+            return await f.readAsString();
+          } else {
+            return null;
+          }
+        } else {
+          return await rootBundle.loadString(file);
+        }
     }
 
     static Future<List<String>> _getAllLocaleFiles(String basePath) async


### PR DESCRIPTION
Hi!

Actually it is not possible to have your locales outside of the rootBundle. This is needed in cases where you download your locales over network and can't have them in the rootBundle.

greetz