### PR TITLE
Flutter 3.0.0 WidgetsBinding.instance is never null

### DIFF
--- a/lib/src/utils/device_locale.dart
+++ b/lib/src/utils/device_locale.dart
@@ -10,7 +10,7 @@ Locale? getCurrentLocale()
 /// Returns preferred device locales
 List<Locale>? getPreferredLocales() 
 {
-    final deviceLocales = WidgetsBinding.instance?.window.locales;
+    final deviceLocales = WidgetsBinding.instance.window.locales;
 
     return deviceLocales;
 }


### PR DESCRIPTION
Remove ! which causes a warning at build time:
../../../../.pub-cache/hosted/pub.dartlang.org/flutter_translate-4.0.2/lib/src/utils/device_locale.dart:13:42: Warning: Operand of null-aware operation '?.' has type 'WidgetsBinding' which excludes null.