### PR TITLE
Support for missing strings fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line
 # is commented out by default.
-#.vscode/
+.vscode/
 
 # Flutter/Dart/Pub related
 **/doc/api/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+This fork is mostly adding some features to work better with community translate tools such as [Weblate](https://weblate.org/).
+- Missing translations fallback to default
+- Support empty interpolations to work as empty strings
 
 [<img src="https://github.com/Jesway/Flutter-Translate/raw/master/resources/images/flutter_translate.png" />](https://github.com/Jesway/Flutter-Translate/)
 

--- a/example/assets/i18n/en.json
+++ b/example/assets/i18n/en.json
@@ -18,6 +18,7 @@
 			"ar": "Arabic",
 			"ru": "Russian"
 		},
+		"fallback_string": "This string is translated in english only",
 		"selected_message": "Currently selected language is {language}",
 		"selection": 
 		{

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_translate/flutter_translate.dart';
+import 'package:flutter_translate_community/flutter_translate_community.dart';
 
 void main() async {
   var delegate = await LocalizationDelegate.create(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,20 +3,19 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_translate/flutter_translate.dart';
 
-void main() async
-{
+void main() async {
   var delegate = await LocalizationDelegate.create(
-          fallbackLocale: 'en_US',
-          supportedLocales: ['en_US', 'es', 'fa', 'ar', 'ru']);
+    fallbackLocale: 'en_US',
+    supportedLocales: ['en_US', 'es', 'fa', 'ar', 'ru'],
+    useFallbackForMissingStrings: true,
+  );
 
   runApp(LocalizedApp(delegate, MyApp()));
 }
 
 class MyApp extends StatelessWidget {
-
   @override
   Widget build(BuildContext context) {
-
     var localizationDelegate = LocalizedApp.of(context).delegate;
 
     return LocalizationProvider(
@@ -32,8 +31,8 @@ class MyApp extends StatelessWidget {
         locale: localizationDelegate.currentLocale,
         theme: ThemeData(primarySwatch: Colors.blue),
         home: MyHomePage(),
-        ),
-      );
+      ),
+    );
   }
 }
 
@@ -46,7 +45,6 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-
   int _counter = 0;
 
   void _decrementCounter() => setState(() => _counter--);
@@ -60,55 +58,61 @@ class _MyHomePageState extends State<MyHomePage> {
     return Scaffold(
       appBar: AppBar(
         title: Text(translate('app_bar.title')),
-        ),
-      body:  Center(
+      ),
+      body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            Text(translate('language.selected_message', args: {'language': translate('language.name.${localizationDelegate.currentLocale.languageCode}')})),
             Padding(
-                    padding: EdgeInsets.only(top: 25, bottom: 160),
-                    child: CupertinoButton.filled(
-                      child: Text(translate('button.change_language')),
-                      padding: const EdgeInsets.symmetric(vertical: 10.0, horizontal: 36.0),
-                      onPressed: () => _onActionSheetPress(context),
-                      )
-                    ),
-
-            Padding(padding: const EdgeInsets.only(bottom: 10),
-                            child: Text(translatePlural('plural.demo', _counter))
-                    ),
+              padding: EdgeInsets.only(top: 25, bottom: 160),
+              child: Text(translate('language.fallback_string')),
+            ),
+            Text(translate('language.selected_message', args: {
+              'language': translate(
+                  'language.name.${localizationDelegate.currentLocale.languageCode}')
+            })),
+            Padding(
+                padding: EdgeInsets.only(top: 25, bottom: 160),
+                child: CupertinoButton.filled(
+                  child: Text(translate('button.change_language')),
+                  padding: const EdgeInsets.symmetric(
+                      vertical: 10.0, horizontal: 36.0),
+                  onPressed: () => _onActionSheetPress(context),
+                )),
+            Padding(
+                padding: const EdgeInsets.only(bottom: 10),
+                child: Text(translatePlural('plural.demo', _counter))),
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 IconButton(
                   icon: Icon(Icons.remove_circle),
                   iconSize: 48,
-                  onPressed: _counter > 0 ? () => setState(() => _decrementCounter()) : null,
-                  ),
+                  onPressed: _counter > 0
+                      ? () => setState(() => _decrementCounter())
+                      : null,
+                ),
                 IconButton(
                   icon: Icon(Icons.add_circle),
                   color: Colors.blue,
                   iconSize: 48,
                   onPressed: () => setState(() => _incrementCounter()),
-                  ),
+                ),
               ],
-              )
-
+            )
           ],
-          ),
         ),
-      );
+      ),
+    );
   }
 
-  void showDemoActionSheet({required BuildContext context, required Widget child}) {
+  void showDemoActionSheet(
+      {required BuildContext context, required Widget child}) {
     showCupertinoModalPopup<String>(
-            context: context,
-            builder: (BuildContext context) => child).then((String? value)
-                                                           {
-                                                            if(value != null)
-                                                             changeLocale(context, value);
-                                                           });
+        context: context,
+        builder: (BuildContext context) => child).then((String? value) {
+      if (value != null) changeLocale(context, value);
+    });
   }
 
   void _onActionSheetPress(BuildContext context) {
@@ -121,26 +125,26 @@ class _MyHomePageState extends State<MyHomePage> {
           CupertinoActionSheetAction(
             child: Text(translate('language.name.en')),
             onPressed: () => Navigator.pop(context, 'en_US'),
-            ),
+          ),
           CupertinoActionSheetAction(
             child: Text(translate('language.name.es')),
             onPressed: () => Navigator.pop(context, 'es'),
-            ),
+          ),
           CupertinoActionSheetAction(
             child: Text(translate('language.name.ar')),
             onPressed: () => Navigator.pop(context, 'ar'),
-            ),
+          ),
           CupertinoActionSheetAction(
             child: Text(translate('language.name.ru')),
             onPressed: () => Navigator.pop(context, 'ru'),
-            ),
+          ),
         ],
         cancelButton: CupertinoActionSheetAction(
           child: Text(translate('button.cancel')),
           isDefaultAction: true,
           onPressed: () => Navigator.pop(context, null),
-          ),
         ),
-      );
+      ),
+    );
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,6 +8,7 @@ void main() async {
     fallbackLocale: 'en_US',
     supportedLocales: ['en_US', 'es', 'fa', 'ar', 'ru'],
     useFallbackForMissingStrings: true,
+    interpolateEmptyAsEmtpyString: true,
   );
 
   runApp(LocalizedApp(delegate, MyApp()));

--- a/example_static_keys/assets/i18n/en.json
+++ b/example_static_keys/assets/i18n/en.json
@@ -18,6 +18,7 @@
 			"ar": "Arabic",
 			"ru": "Russian"
 		},
+		"fallback_string": "This string is translated in english only",
 		"selected_message": "Currently selected language is {language}",
 		"selection": 
 		{

--- a/example_static_keys/lib/localization/keys.g.dart
+++ b/example_static_keys/lib/localization/keys.g.dart
@@ -40,4 +40,6 @@ class Keys {
   static const String Plural_Demo_Few = 'plural.demo.few';
 
   static const String Plural_Demo_Many = 'plural.demo.many';
+
+  static const String Language_Fallback_String = 'language.fallback_string';
 }

--- a/example_static_keys/lib/main.dart
+++ b/example_static_keys/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_translate/flutter_translate.dart';
+import 'package:flutter_translate_community/flutter_translate_community.dart';
 
 import 'localization/keys.dart';
 

--- a/example_static_keys/lib/main.dart
+++ b/example_static_keys/lib/main.dart
@@ -5,20 +5,19 @@ import 'package:flutter_translate/flutter_translate.dart';
 
 import 'localization/keys.dart';
 
-void main() async
-{
+void main() async {
   var delegate = await LocalizationDelegate.create(
-          fallbackLocale: 'en_US',
-          supportedLocales: ['en_US', 'es', 'fa', 'ar']);
+    fallbackLocale: 'en_US',
+    supportedLocales: ['en_US', 'es', 'fa', 'ar'],
+    useFallbackForMissingStrings: true,
+  );
 
   runApp(LocalizedApp(delegate, MyApp()));
 }
 
 class MyApp extends StatelessWidget {
-
   @override
   Widget build(BuildContext context) {
-
     var localizationDelegate = LocalizedApp.of(context).delegate;
 
     return LocalizationProvider(
@@ -48,7 +47,6 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-
   int _counter = 0;
 
   void _decrementCounter() => setState(() => _counter--);
@@ -63,30 +61,38 @@ class _MyHomePageState extends State<MyHomePage> {
       appBar: AppBar(
         title: Text(translate(Keys.App_Bar_Title)),
       ),
-      body:  Center(
+      body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            Text(translate(Keys.Language_Selected_Message, args: {'language': translate(getCurrentLanguageLocalizationKey(localizationDelegate.currentLocale.languageCode))})),
             Padding(
-                    padding: EdgeInsets.only(top: 25, bottom: 160),
-                    child: CupertinoButton.filled(
-                      child: Text(translate(Keys.Button_Change_Language)),
-                      padding: const EdgeInsets.symmetric(vertical: 10.0, horizontal: 36.0),
-                      onPressed: () => _onActionSheetPress(context),
-                    )
+              padding: EdgeInsets.only(top: 25, bottom: 160),
+              child: Text(translate(Keys.Language_Fallback_String)),
             ),
-
-            Padding(padding: const EdgeInsets.only(bottom: 10),
-                    child: Text(translatePlural(Keys.Plural_Demo, _counter))
-            ),
+            Text(translate(Keys.Language_Selected_Message, args: {
+              'language': translate(getCurrentLanguageLocalizationKey(
+                  localizationDelegate.currentLocale.languageCode))
+            })),
+            Padding(
+                padding: EdgeInsets.only(top: 25, bottom: 160),
+                child: CupertinoButton.filled(
+                  child: Text(translate(Keys.Button_Change_Language)),
+                  padding: const EdgeInsets.symmetric(
+                      vertical: 10.0, horizontal: 36.0),
+                  onPressed: () => _onActionSheetPress(context),
+                )),
+            Padding(
+                padding: const EdgeInsets.only(bottom: 10),
+                child: Text(translatePlural(Keys.Plural_Demo, _counter))),
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 IconButton(
                   icon: Icon(Icons.remove_circle),
                   iconSize: 48,
-                  onPressed: _counter > 0 ? () => setState(() => _decrementCounter()) : null,
+                  onPressed: _counter > 0
+                      ? () => setState(() => _decrementCounter())
+                      : null,
                 ),
                 IconButton(
                   icon: Icon(Icons.add_circle),
@@ -96,20 +102,18 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
               ],
             )
-
           ],
         ),
       ),
     );
   }
 
-  void showDemoActionSheet({required BuildContext context, required Widget child}) {
+  void showDemoActionSheet(
+      {required BuildContext context, required Widget child}) {
     showCupertinoModalPopup<String>(
-            context: context,
-            builder: (BuildContext context) => child).then((String? value)
-    {
-      if(value != null)
-      changeLocale(context, value);
+        context: context,
+        builder: (BuildContext context) => child).then((String? value) {
+      if (value != null) changeLocale(context, value);
     });
   }
 
@@ -146,17 +150,19 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 
-
-  getCurrentLanguageLocalizationKey(String code)
-  {
-    switch(code)
-    {
+  getCurrentLanguageLocalizationKey(String code) {
+    switch (code) {
       case "en":
-      case "en_US": return Keys.Language_Name_En;
-      case "es": return Keys.Language_Name_Es;
-      case "ar": return Keys.Language_Name_Ar;
-        case "ru": return Keys.Language_Name_Ru;
-        default: return null;
+      case "en_US":
+        return Keys.Language_Name_En;
+      case "es":
+        return Keys.Language_Name_Es;
+      case "ar":
+        return Keys.Language_Name_Ar;
+      case "ru":
+        return Keys.Language_Name_Ru;
+      default:
+        return null;
     }
   }
 }

--- a/lib/flutter_translate_community.dart
+++ b/lib/flutter_translate_community.dart
@@ -1,4 +1,4 @@
-library flutter_translate;
+library flutter_translate_community;
 
 export 'src/utils/utils.dart';
 export 'src/services/localization.dart';

--- a/lib/src/delegates/localization_delegate.dart
+++ b/lib/src/delegates/localization_delegate.dart
@@ -18,6 +18,8 @@ class LocalizationDelegate extends LocalizationsDelegate<Localization> {
 
   final bool fallbackForMissingStrings;
 
+  final bool interpolateEmptyAsEmtpyString;
+
   LocaleChangedCallback? onLocaleChanged;
 
   Locale get currentLocale => _currentLocale!;
@@ -28,6 +30,7 @@ class LocalizationDelegate extends LocalizationsDelegate<Localization> {
     this.supportedLocalesMap,
     this.preferences,
     this.fallbackForMissingStrings,
+    this.interpolateEmptyAsEmtpyString,
   );
 
   Future changeLocale(Locale newLocale) async {
@@ -47,7 +50,11 @@ class LocalizationDelegate extends LocalizationsDelegate<Localization> {
                 fallbackLocale, supportedLocalesMap)
             : null;
 
-    Localization.load(localizedContent, fallback: fallbackContent);
+    Localization.load(
+      localizedContent,
+      fallback: fallbackContent,
+      interpolateEmptyAsEmtpyString: interpolateEmptyAsEmtpyString,
+    );
 
     _currentLocale = locale;
 
@@ -81,6 +88,7 @@ class LocalizationDelegate extends LocalizationsDelegate<Localization> {
       {required String fallbackLocale,
       required List<String> supportedLocales,
       bool? useFallbackForMissingStrings,
+      bool? interpolateEmptyAsEmtpyString,
       String basePath = Constants.localizedAssetsPath,
       ITranslatePreferences? preferences}) async {
     WidgetsFlutterBinding.ensureInitialized();
@@ -92,8 +100,14 @@ class LocalizationDelegate extends LocalizationsDelegate<Localization> {
 
     ConfigurationValidator.validate(fallback, locales);
 
-    var delegate = LocalizationDelegate._(fallback, locales, localesMap,
-        preferences, useFallbackForMissingStrings ?? false);
+    var delegate = LocalizationDelegate._(
+      fallback,
+      locales,
+      localesMap,
+      preferences,
+      useFallbackForMissingStrings ?? false,
+      interpolateEmptyAsEmtpyString ?? false,
+    );
 
     if (!await delegate._loadPreferences()) {
       await delegate._loadDeviceLocale();

--- a/lib/src/delegates/localization_delegate.dart
+++ b/lib/src/delegates/localization_delegate.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
-import 'package:flutter_translate/flutter_translate.dart';
-import 'package:flutter_translate/src/constants/constants.dart';
-import 'package:flutter_translate/src/services/locale_service.dart';
-import 'package:flutter_translate/src/validators/configuration_validator.dart';
+import 'package:flutter_translate_community/flutter_translate_community.dart';
+import 'package:flutter_translate_community/src/constants/constants.dart';
+import 'package:flutter_translate_community/src/services/locale_service.dart';
+import 'package:flutter_translate_community/src/validators/configuration_validator.dart';
 
 class LocalizationDelegate extends LocalizationsDelegate<Localization> {
   Locale? _currentLocale;

--- a/lib/src/services/locale_file_service.dart
+++ b/lib/src/services/locale_file_service.dart
@@ -1,69 +1,63 @@
 import 'dart:convert';
 import 'package:flutter/services.dart';
-import 'package:flutter_translate/src/constants/constants.dart';
+import 'package:flutter_translate_community/src/constants/constants.dart';
 
-class LocaleFileService
-{
-    static Future<Map<String, String>> getLocaleFiles(List<String> locales, String basePath) async
-    {
-        var localizedFiles = await _getAllLocaleFiles(basePath);
+class LocaleFileService {
+  static Future<Map<String, String>> getLocaleFiles(
+      List<String> locales, String basePath) async {
+    var localizedFiles = await _getAllLocaleFiles(basePath);
 
-        final files = new Map<String, String>();
+    final files = new Map<String, String>();
 
-        for(final language in locales.toSet())
-        {
-            var file = _findLocaleFile(language, localizedFiles, basePath);
+    for (final language in locales.toSet()) {
+      var file = _findLocaleFile(language, localizedFiles, basePath);
 
-            files[language] = file;
-        }
-
-        return files;
+      files[language] = file;
     }
 
-    static Future<String?> getLocaleContent(String file) async
-    {
-        final ByteData? data = await rootBundle.load(file);
+    return files;
+  }
 
-        if (data == null) return null;
-        
-        return utf8.decode(data.buffer.asUint8List());
+  static Future<String?> getLocaleContent(String file) async {
+    final ByteData? data = await rootBundle.load(file);
+
+    if (data == null) return null;
+
+    return utf8.decode(data.buffer.asUint8List());
+  }
+
+  static Future<List<String>> _getAllLocaleFiles(String basePath) async {
+    final manifest =
+        await rootBundle.loadString(Constants.assetManifestFilename);
+
+    Map<String, dynamic> map = jsonDecode(manifest);
+
+    var separator = basePath.endsWith('/') ? '' : '/';
+
+    return map.keys.where((x) => x.startsWith('$basePath$separator')).toList();
+  }
+
+  static String _findLocaleFile(
+      String languageCode, List<String> localizedFiles, String basePath) {
+    var file = _getFilepath(languageCode, basePath);
+
+    if (!localizedFiles.contains(file)) {
+      if (languageCode.contains('_')) {
+        file = _getFilepath(languageCode.split('_').first, basePath);
+      }
     }
 
-    static Future<List<String>> _getAllLocaleFiles(String basePath) async
-    {
-        final manifest = await rootBundle.loadString(Constants.assetManifestFilename);
-
-        Map<String, dynamic> map = jsonDecode(manifest);
-
-        var separator = basePath.endsWith('/') ? '' : '/';
-
-        return map.keys.where((x) => x.startsWith('$basePath$separator')).toList();
+    if (file == null) {
+      throw new Exception(
+          'The asset file for the language "$languageCode" was not found.');
     }
 
-    static String _findLocaleFile(String languageCode, List<String> localizedFiles, String basePath)
-    {
-        var file = _getFilepath(languageCode, basePath);
+    return file;
+  }
 
-        if(!localizedFiles.contains(file))
-        {
-            if(languageCode.contains('_'))
-            {
-                file = _getFilepath(languageCode.split('_').first, basePath);
-            }
-        }
+  static String? _getFilepath(String languageCode, String basePath) {
+    var separator = basePath.endsWith('/') ? '' : '/';
 
-        if(file == null)
-        {
-            throw new Exception('The asset file for the language "$languageCode" was not found.');
-        }
-
-        return file;
-    }
-
-    static String? _getFilepath(String languageCode, String basePath)
-    {
-        var separator = basePath.endsWith('/') ? '' : '/';
-
-        return '$basePath$separator$languageCode.json';
-    }
+    return '$basePath$separator$languageCode.json';
+  }
 }

--- a/lib/src/services/locale_service.dart
+++ b/lib/src/services/locale_service.dart
@@ -1,62 +1,53 @@
 import 'dart:convert';
 import 'dart:ui';
-import 'package:flutter_translate/flutter_translate.dart';
+import 'package:flutter_translate_community/flutter_translate_community.dart';
 
 import 'locale_file_service.dart';
 
-class LocaleService
-{
-    static Future<Map<Locale, String>> getLocalesMap(List<String> locales, String basePath) async
-    {
-        var files = await LocaleFileService.getLocaleFiles(locales, basePath);
+class LocaleService {
+  static Future<Map<Locale, String>> getLocalesMap(
+      List<String> locales, String basePath) async {
+    var files = await LocaleFileService.getLocaleFiles(locales, basePath);
 
-        return files.map((x,y) => MapEntry(localeFromString(x), y));
+    return files.map((x, y) => MapEntry(localeFromString(x), y));
+  }
+
+  static Locale? findLocale(Locale locale, List<Locale> supportedLocales) {
+    // Not supported by all null safety versions
+    Locale?
+        existing; // = supportedLocales.firstWhereOrNull((x) => x == locale);
+
+    for (var x in supportedLocales) {
+      if (x == locale) {
+        existing = x;
+        break;
+      }
     }
 
-    static Locale? findLocale(Locale locale, List<Locale> supportedLocales)
-    {
-        // Not supported by all null safety versions
-        Locale? existing; // = supportedLocales.firstWhereOrNull((x) => x == locale);
-
-        for (var x in supportedLocales) 
-        {
-            if (x == locale) 
-            {
-                existing = x;
-                break;
-            }
+    if (existing == null) {
+      // Not supported by all null safety versions
+      // existing = supportedLocales.firstWhereOrNull((x) => x.languageCode == locale.languageCode);
+      for (var x in supportedLocales) {
+        if (x.languageCode == locale.languageCode) {
+          existing = x;
+          break;
         }
-
-        if(existing == null)
-        {
-            // Not supported by all null safety versions
-            // existing = supportedLocales.firstWhereOrNull((x) => x.languageCode == locale.languageCode);
-            for (var x in supportedLocales) 
-            {
-                if (x.languageCode == locale.languageCode) 
-                {
-                    existing = x;
-                    break;
-                }
-            }
-
-        }
-
-        return existing;
+      }
     }
 
-    static Future<Map<String, dynamic>> getLocaleContent(Locale locale, Map<Locale, String> supportedLocales) async
-    {
-        var file = supportedLocales[locale];
+    return existing;
+  }
 
-        if (file == null) return {};
+  static Future<Map<String, dynamic>> getLocaleContent(
+      Locale locale, Map<Locale, String> supportedLocales) async {
+    var file = supportedLocales[locale];
 
-        var content = await LocaleFileService.getLocaleContent(file);
-        
-        if (content == null) return {};
+    if (file == null) return {};
 
-        return json.decode(content);
-    }
+    var content = await LocaleFileService.getLocaleContent(file);
 
+    if (content == null) return {};
 
+    return json.decode(content);
+  }
 }

--- a/lib/src/services/localization.dart
+++ b/lib/src/services/localization.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_translate/src/constants/constants.dart';
+import 'package:flutter_translate_community/src/constants/constants.dart';
 import 'package:intl/intl.dart';
 
 class Localization {

--- a/lib/src/services/localization.dart
+++ b/lib/src/services/localization.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 class Localization {
   late Map<String, dynamic> _translations;
   Map<String, dynamic>? _fallbackTranslations;
+  bool? _interpolateEmptyAsEmtpyString;
 
   Localization._();
 
@@ -12,9 +13,10 @@ class Localization {
       _instance ?? (_instance = Localization._());
 
   static void load(Map<String, dynamic> translations,
-      {Map<String, dynamic>? fallback}) {
+      {Map<String, dynamic>? fallback, bool? interpolateEmptyAsEmtpyString}) {
     instance._translations = translations;
     instance._fallbackTranslations = fallback;
+    instance._interpolateEmptyAsEmtpyString = interpolateEmptyAsEmtpyString;
   }
 
   String translate(String key, {Map<String, dynamic>? args}) {
@@ -76,6 +78,9 @@ class Localization {
   String _assignArguments(String value, Map<String, dynamic> args) {
     for (final key in args.keys) {
       value = value.replaceAll('{$key}', '${args[key]}');
+      if (_interpolateEmptyAsEmtpyString ?? false) {
+        value = value.replaceAll('{}', '');
+      }
     }
 
     return value;

--- a/lib/src/services/localization.dart
+++ b/lib/src/services/localization.dart
@@ -23,8 +23,8 @@ class Localization {
     var translation =
         _getTranslation(key, _translations, _fallbackTranslations);
 
-    if (translation != null && args != null) {
-      translation = _assignArguments(translation, args);
+    if (translation != null) {
+      translation = _assignArguments(translation, args ?? {});
     }
 
     return translation ?? key;
@@ -49,9 +49,9 @@ class Localization {
     var translations =
         _getListTranslation(key, _translations, _fallbackTranslations);
 
-    if (translations != null && args != null) {
+    if (translations != null) {
       translations =
-          translations.map((t) => _assignArguments(t, args)).toList();
+          translations.map((t) => _assignArguments(t, args ?? {})).toList();
     }
 
     return List<String>.from(translations ?? [key]);
@@ -71,6 +71,9 @@ class Localization {
     for (String k in args.keys) {
       template = template!.replaceAll("{$k}", args[k].toString());
     }
+    if (_interpolateEmptyAsEmtpyString ?? false) {
+      template = template!.replaceAll('{}', '');
+    }
 
     return template;
   }
@@ -78,9 +81,9 @@ class Localization {
   String _assignArguments(String value, Map<String, dynamic> args) {
     for (final key in args.keys) {
       value = value.replaceAll('{$key}', '${args[key]}');
-      if (_interpolateEmptyAsEmtpyString ?? false) {
-        value = value.replaceAll('{}', '');
-      }
+    }
+    if (_interpolateEmptyAsEmtpyString ?? false) {
+      value = value.replaceAll('{}', '');
     }
 
     return value;

--- a/lib/src/services/localization.dart
+++ b/lib/src/services/localization.dart
@@ -1,129 +1,155 @@
-
 import 'package:flutter_translate/src/constants/constants.dart';
 import 'package:intl/intl.dart';
 
-class Localization
-{
-    late Map<String, dynamic> _translations;
-    Map<String, dynamic>? _fallbackTranslations;
+class Localization {
+  late Map<String, dynamic> _translations;
+  Map<String, dynamic>? _fallbackTranslations;
 
-    Localization._();
+  Localization._();
 
-    static Localization? _instance;
-    static Localization get instance => _instance ?? (_instance = Localization._());
+  static Localization? _instance;
+  static Localization get instance =>
+      _instance ?? (_instance = Localization._());
 
-    static void load(Map<String, dynamic> translations, {Map<String, dynamic>? fallback})
-    {
-        instance._translations = translations;
-        instance._fallbackTranslations = fallback;
+  static void load(Map<String, dynamic> translations,
+      {Map<String, dynamic>? fallback}) {
+    instance._translations = translations;
+    instance._fallbackTranslations = fallback;
+  }
+
+  String translate(String key, {Map<String, dynamic>? args}) {
+    var translation =
+        _getTranslation(key, _translations, _fallbackTranslations);
+
+    if (translation != null && args != null) {
+      translation = _assignArguments(translation, args);
     }
 
-    String translate(String key, {Map<String, dynamic>? args})
-    {
-        var translation = _getTranslation(key, _translations, _fallbackTranslations);
+    return translation ?? key;
+  }
 
-        if (translation != null && args != null)
-        {
-            translation = _assignArguments(translation, args);
-        }
+  String plural(String key, num value, {Map<String, dynamic>? args}) {
+    final forms = _getAllPluralForms(key, _translations, _fallbackTranslations);
 
-        return translation ?? key;
+    return Intl.plural(
+      value,
+      zero: _putArgs(forms[Constants.pluralZero], value, args: args),
+      one: _putArgs(forms[Constants.pluralOne], value, args: args),
+      two: _putArgs(forms[Constants.pluralTwo], value, args: args),
+      few: _putArgs(forms[Constants.pluralFew], value, args: args),
+      many: _putArgs(forms[Constants.pluralMany], value, args: args),
+      other: _putArgs(forms[Constants.pluralOther], value, args: args) ??
+          '$key.${Constants.pluralOther}',
+    );
+  }
+
+  List<String> list(String key, {Map<String, dynamic>? args}) {
+    var translations =
+        _getListTranslation(key, _translations, _fallbackTranslations);
+
+    if (translations != null && args != null) {
+      translations =
+          translations.map((t) => _assignArguments(t, args)).toList();
     }
 
-    String plural(String key, num value, {Map<String, dynamic>? args})
-    {
-        final forms = _getAllPluralForms(key, _translations);
+    return List<String>.from(translations ?? [key]);
+  }
 
-        return Intl.plural(
-            value,
-            zero: _putArgs(forms[Constants.pluralZero], value, args: args),
-            one: _putArgs(forms[Constants.pluralOne], value, args: args),
-            two: _putArgs(forms[Constants.pluralTwo], value, args: args),
-            few: _putArgs(forms[Constants.pluralFew], value, args: args),
-            many: _putArgs(forms[Constants.pluralMany], value, args: args),
-            other: _putArgs(forms[Constants.pluralOther], value, args: args) ?? '$key.${Constants.pluralOther}',
-        );
+  String? _putArgs(String? template, num value, {Map<String, dynamic>? args}) {
+    if (template == null) {
+      return null;
     }
 
-    String? _putArgs(String? template, num value, {Map<String, dynamic>? args})
-    {
-        if (template == null) 
-        {
-            return null;
-        }
+    template = template.replaceAll(Constants.pluralValueArg, value.toString());
 
-        template = template.replaceAll(Constants.pluralValueArg, value.toString());
-
-        if (args == null)
-        {
-            return template;
-        }
-
-        for (String k in args.keys)
-        {
-            template = template!.replaceAll("{$k}", args[k].toString());
-        }
-
-        return template;
+    if (args == null) {
+      return template;
     }
 
-    String _assignArguments(String value, Map<String, dynamic> args)
-    {
-        for(final key in args.keys)
-        {
-            value = value.replaceAll('{$key}', '${args[key]}');
-        }
-
-        return value;
+    for (String k in args.keys) {
+      template = template!.replaceAll("{$k}", args[k].toString());
     }
 
-    String? _getTranslation(String key, Map<String, dynamic> map, Map<String, dynamic>? fallbackMap)
-    {
-        List<String> keys = key.split('.');
+    return template;
+  }
 
-        if (keys.length > 1)
-        {
-            var firstKey = keys.first;
-            var remainingKey = key.substring(key.indexOf('.') + 1);
-
-             var value = map[firstKey];
-            if (value != null && value is! String)
-            {
-                return _getTranslation(remainingKey, value, fallbackMap?[firstKey]);
-            } else if (fallbackMap != null)
-            {
-                var fallbackValue = fallbackMap[firstKey];
-                if (fallbackValue != null && fallbackValue is! String)
-                {
-                    return _getTranslation(remainingKey, fallbackValue, null);
-                }
-            }
-        }
-
-        return map[key] ?? (fallbackMap?[key]);
+  String _assignArguments(String value, Map<String, dynamic> args) {
+    for (final key in args.keys) {
+      value = value.replaceAll('{$key}', '${args[key]}');
     }
 
-    Map<String, String> _getAllPluralForms(String key, Map<String, dynamic> map) 
-    {
-        List<String> keys = key.split('.');
+    return value;
+  }
 
-        if (keys.length > 1) 
-        {
-            var firstKey = keys.first;
+  String? _getTranslation(
+      String key, Map<String, dynamic> map, Map<String, dynamic>? fallbackMap) {
+    List<String> keys = key.split('.');
 
-            if (map.containsKey(firstKey) && map[firstKey] is! String) 
-            {
-                return _getAllPluralForms(key.substring(key.indexOf('.') + 1), map[firstKey]);
-            }
+    if (keys.length > 1) {
+      var firstKey = keys.first;
+      var remainingKey = key.substring(key.indexOf('.') + 1);
+
+      var value = map[firstKey];
+      if (value != null && value is! String) {
+        return _getTranslation(remainingKey, value, fallbackMap?[firstKey]);
+      } else if (fallbackMap != null) {
+        var fallbackValue = fallbackMap[firstKey];
+        if (fallbackValue != null && fallbackValue is! String) {
+          return _getTranslation(remainingKey, fallbackValue, null);
         }
-
-        final result = <String, String>{};
-
-        for (String k in map[key].keys) 
-        {
-            result[k] = map[key][k].toString();
-        }
-
-        return result;
+      }
     }
+
+    return map[key] ?? fallbackMap?[key];
+  }
+
+  Map<String, String> _getAllPluralForms(
+      String key, Map<String, dynamic> map, Map<String, dynamic>? fallbackMap) {
+    List<String> keys = key.split('.');
+
+    if (keys.length > 1) {
+      var firstKey = keys.first;
+      var remainingKey = key.substring(key.indexOf('.') + 1);
+
+      var value = map[firstKey];
+      if (value != null && value is! String) {
+        return _getAllPluralForms(remainingKey, value, fallbackMap?[firstKey]);
+      } else if (fallbackMap != null) {
+        var fallbackValue = fallbackMap[firstKey];
+        if (fallbackValue != null && fallbackValue is! String) {
+          return _getAllPluralForms(remainingKey, fallbackValue, null);
+        }
+      }
+    }
+
+    final result = <String, String>{};
+
+    for (String k in map[key].keys.toSet().addAll(fallbackMap?[key].keys)) {
+      result[k] = (map[key][k] ?? fallbackMap?[key][k]).toString();
+    }
+
+    return result;
+  }
+
+  List<dynamic>? _getListTranslation(
+      String key, Map<String, dynamic> map, Map<String, dynamic>? fallbackMap) {
+    List<String> keys = key.split('.');
+
+    if (keys.length > 1) {
+      var firstKey = keys.first;
+      var remainingKey = key.substring(key.indexOf('.') + 1);
+
+      var value = map[firstKey];
+      if (value != null && value is! List<dynamic>) {
+        return _getListTranslation(remainingKey, value, fallbackMap?[firstKey]);
+      } else if (fallbackMap != null) {
+        var fallbackValue = fallbackMap[firstKey];
+        if (fallbackValue != null && fallbackValue is! List<dynamic>) {
+          return _getListTranslation(remainingKey, fallbackValue, null);
+        }
+      }
+    }
+
+    return map[key] ?? fallbackMap?[key];
+  }
 }

--- a/lib/src/services/localization_configuration.dart
+++ b/lib/src/services/localization_configuration.dart
@@ -1,61 +1,65 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_translate/flutter_translate.dart';
-import 'package:flutter_translate/src/constants/constants.dart';
+import 'package:flutter_translate_community/flutter_translate_community.dart';
+import 'package:flutter_translate_community/src/constants/constants.dart';
 import 'locale_file_service.dart';
 
-class LocalizationConfiguration
-{
-    Map<Locale, String>? _localizations;
+class LocalizationConfiguration {
+  Map<Locale, String>? _localizations;
 
-    Map<Locale, String>? get localizations => _localizations;
+  Map<Locale, String>? get localizations => _localizations;
 
-    final Locale fallbackLocale;
+  final Locale fallbackLocale;
 
-    final List<Locale> supportedLocales;
+  final List<Locale> supportedLocales;
 
-    LocalizationConfiguration._(this.fallbackLocale, this.supportedLocales);
+  LocalizationConfiguration._(this.fallbackLocale, this.supportedLocales);
 
-    static Future<LocalizationConfiguration> create(String fallbackLanguage, List<String> supportedLanguages, {String basePath = Constants.localizedAssetsPath}) async
-    {
-        var configuration = new LocalizationConfiguration._(localeFromString(fallbackLanguage), _generateSupportedLocales(supportedLanguages));
+  static Future<LocalizationConfiguration> create(
+      String fallbackLanguage, List<String> supportedLanguages,
+      {String basePath = Constants.localizedAssetsPath}) async {
+    var configuration = new LocalizationConfiguration._(
+        localeFromString(fallbackLanguage),
+        _generateSupportedLocales(supportedLanguages));
 
-        _validateConfiguration(fallbackLanguage, supportedLanguages);
+    _validateConfiguration(fallbackLanguage, supportedLanguages);
 
-        var files = await LocaleFileService.getLocaleFiles(supportedLanguages, basePath);
+    var files =
+        await LocaleFileService.getLocaleFiles(supportedLanguages, basePath);
 
-        configuration._localizations = files.map((x,y) => _getLocalizedEntry(x, y));
+    configuration._localizations =
+        files.map((x, y) => _getLocalizedEntry(x, y));
 
-        return configuration;
+    return configuration;
+  }
+
+  static void _validateConfiguration(
+      String fallbackLanguage, List<String> supportedLanguages) {
+    if (!supportedLanguages.contains(fallbackLanguage)) {
+      throw new Exception(
+          'The fallbackLanguage [$fallbackLanguage] must be present in the supportedLanguages list [${supportedLanguages.join(", ")}].');
+    }
+  }
+
+  static List<Locale> _generateSupportedLocales(
+      List<String> supportedLanguages) {
+    return supportedLanguages
+        .map((x) => localeFromString(x, languageCodeOnly: true))
+        .toSet()
+        .toList();
+  }
+
+  static MapEntry<Locale, String> _getLocalizedEntry(
+      String languageCode, String file) {
+    Locale locale;
+
+    if (languageCode.contains('_')) {
+      var parts = languageCode.split('_');
+
+      locale = new Locale(parts[0], parts[1]);
+    } else {
+      locale = new Locale(languageCode);
     }
 
-    static void _validateConfiguration(String fallbackLanguage, List<String> supportedLanguages)
-    {
-        if(!supportedLanguages.contains(fallbackLanguage))
-        {
-            throw new Exception('The fallbackLanguage [$fallbackLanguage] must be present in the supportedLanguages list [${supportedLanguages.join(", ")}].');
-        }
-    }
-
-    static List<Locale> _generateSupportedLocales(List<String> supportedLanguages)
-    {
-        return supportedLanguages.map((x) => localeFromString(x, languageCodeOnly: true)).toSet().toList();
-    }
-
-    static MapEntry<Locale, String> _getLocalizedEntry(String languageCode, String file)
-    {
-        Locale locale;
-
-        if(languageCode.contains('_'))
-        {
-            var parts = languageCode.split('_');
-
-            locale = new Locale(parts[0], parts[1]);
-        }
-        else
-        {
-            locale = new Locale(languageCode);
-        }
-
-        return MapEntry(locale, file);
-    }
+    return MapEntry(locale, file);
+  }
 }

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_translate/flutter_translate.dart';
+import 'package:flutter_translate_community/flutter_translate_community.dart';
 
 typedef LocaleChangedCallback = Future Function(Locale locale);
 

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -3,44 +3,44 @@ import 'package:flutter_translate/flutter_translate.dart';
 
 typedef LocaleChangedCallback = Future Function(Locale locale);
 
-Locale localeFromString(String code, {bool languageCodeOnly = false})
-{
-	if (code.contains('_'))
-	{
-		var parts = code.split('_');
+Locale localeFromString(String code, {bool languageCodeOnly = false}) {
+  if (code.contains('_')) {
+    var parts = code.split('_');
 
-		return languageCodeOnly ? Locale(parts[0]) : Locale(parts[0], parts[1]);
-	}
-	else
-	{
-		return Locale(code);
-	}
+    return languageCodeOnly ? Locale(parts[0]) : Locale(parts[0], parts[1]);
+  } else {
+    return Locale(code);
+  }
 }
 
-String localeToString(Locale locale)
-{
-	return locale.countryCode != null ? '${locale.languageCode}_${locale.countryCode}' : locale.languageCode;
+String localeToString(Locale locale) {
+  return locale.countryCode != null
+      ? '${locale.languageCode}_${locale.countryCode}'
+      : locale.languageCode;
 }
 
 /// Translate the selected key into the currently selected locale
-String translate(String key, {Map<String, dynamic>? args})
-{
-	return Localization.instance.translate(key, args: args);
+String translate(String key, {Map<String, dynamic>? args}) {
+  return Localization.instance.translate(key, args: args);
 }
 
 /// Translate the selected key into the currently selected locale using pluralization
-String translatePlural(String key, num value, {Map<String, dynamic>? args})
-{
-	return Localization.instance.plural(key, value, args: args);
+String translatePlural(String key, num value, {Map<String, dynamic>? args}) {
+  return Localization.instance.plural(key, value, args: args);
+}
+
+/// Translate the selected key into the currently selected locale returning a list of strings
+List<String> translateList(String key, {Map<String, dynamic>? args}) {
+  return Localization.instance.list(key, args: args);
 }
 
 /// Change the currently selected locale
-Future changeLocale(BuildContext context, String? localeCode) async
-{
-	if (localeCode != null)
-	{
-		await LocalizedApp.of(context).delegate.changeLocale(localeFromString(localeCode));
+Future changeLocale(BuildContext context, String? localeCode) async {
+  if (localeCode != null) {
+    await LocalizedApp.of(context)
+        .delegate
+        .changeLocale(localeFromString(localeCode));
 
-		LocalizationProvider.of(context).state.onLocaleChanged();
-	}
+    LocalizationProvider.of(context).state.onLocaleChanged();
+  }
 }

--- a/lib/src/widgets/localization_provider.dart
+++ b/lib/src/widgets/localization_provider.dart
@@ -1,16 +1,17 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_translate/flutter_translate.dart';
+import 'package:flutter_translate_community/flutter_translate_community.dart';
 
-class LocalizationProvider extends InheritedWidget
-{
-    final LocalizedAppState state;
+class LocalizationProvider extends InheritedWidget {
+  final LocalizedAppState state;
 
-    final Widget child;
+  final Widget child;
 
-    LocalizationProvider({Key? key, required this.child, required this.state}) : super(key: key, child: child);
+  LocalizationProvider({Key? key, required this.child, required this.state})
+      : super(key: key, child: child);
 
-    static LocalizationProvider of(BuildContext context) => (context.dependOnInheritedWidgetOfExactType<LocalizationProvider>())!;
+  static LocalizationProvider of(BuildContext context) =>
+      (context.dependOnInheritedWidgetOfExactType<LocalizationProvider>())!;
 
-    @override
-    bool updateShouldNotify(LocalizationProvider oldWidget) => true;
+  @override
+  bool updateShouldNotify(LocalizationProvider oldWidget) => true;
 }

--- a/lib/src/widgets/localized_app.dart
+++ b/lib/src/widgets/localized_app.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_translate/flutter_translate.dart';
+import 'package:flutter_translate_community/flutter_translate_community.dart';
 
-class LocalizedApp extends StatefulWidget
-{
-    final Widget child;
+class LocalizedApp extends StatefulWidget {
+  final Widget child;
 
-    final LocalizationDelegate delegate;
+  final LocalizationDelegate delegate;
 
-    LocalizedApp(this.delegate, this.child);
+  LocalizedApp(this.delegate, this.child);
 
-    LocalizedAppState createState() => LocalizedAppState();
+  LocalizedAppState createState() => LocalizedAppState();
 
-    static LocalizedApp of(BuildContext context) => context.findAncestorWidgetOfExactType<LocalizedApp>()!;
+  static LocalizedApp of(BuildContext context) =>
+      context.findAncestorWidgetOfExactType<LocalizedApp>()!;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,7 @@
-name: flutter_translate
-description: Flutter Translate is a fully featured localization / internationalization (i18n) library for Flutter.
+name: flutter_translate_community
+description: Flutter Translate is a fully featured localization / internationalization (i18n) library for Flutter (community translation fork).
 version: 4.0.3
-homepage: https://jesway.com
-repository: https://github.com/Jesway/Flutter-Translate
+repository: https://github.com/guillaumeboehm/Flutter-Translate
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Opening a new pr following #46 with the feature as an opt-in option, updated examples, and for the wiki the only relevant change seems to be this:
````diff
diff --git a/1.-Installation,-Configuration-&-Usage.md b/1.-Installation,-Configuration-&-Usage.md
index 40c1400..34608d0 100644
--- a/1.-Installation,-Configuration-&-Usage.md
+++ b/1.-Installation,-Configuration-&-Usage.md
@@ -55,6 +55,15 @@ If the assets directory for the localization files is different than the default
       ...
 ```
 
+If you want your translations to use the fallback locale in case of missing strings in the translation files you can set this option (default is ```false```):
+
+```dart
+ var delegate = await LocalizationDelegate.create(
+      ...
+        useFallbackForMissingStrings: true
+      ...
+```
+
 Example MyApp:
 
 ```dart
````