### PR TITLE
Add translateIfExists API which returns null if the translation key i…

### DIFF
--- a/lib/src/services/localization.dart
+++ b/lib/src/services/localization.dart
@@ -28,6 +28,17 @@ class Localization
         return translation ?? key;
     }
 
+    String? translateIfExists(String key, {Map<String, dynamic>? args}) 
+    {
+        var translation = _getTranslation(key, _translations);
+
+        if (translation != null && args != null) {
+            translation = _assignArguments(translation, args);
+        }
+
+        return translation;
+    }
+
     String plural(String key, num value, {Map<String, dynamic>? args})
     {
         final forms = _getAllPluralForms(key, _translations);

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -28,6 +28,13 @@ String translate(String key, {Map<String, dynamic>? args})
 	return Localization.instance.translate(key, args: args);
 }
 
+/// Translate the selected key into the currently selected locale.
+/// If the selected translation key is not found, returns null.
+String? translateIfExists(String key, {Map<String, dynamic>? args}) 
+{
+  return Localization.instance.translateIfExists(key, args: args);
+}
+
 /// Translate the selected key into the currently selected locale using pluralization
 String translatePlural(String key, num value, {Map<String, dynamic>? args})
 {


### PR DESCRIPTION
Add translateIfExists API which returns null if the translation key is not found.
This enables the caller to know that the translation is not available and act accordingly.